### PR TITLE
Fix typos in docs and serial output

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 ### Getting started
 
-Go to the [WIKI](https://github.com/pesor/TTGO-T-HIGrow/wiki), there you will find a comprehensive toturial to help you implement this card.
+Go to the [WIKI](https://github.com/pesor/TTGO-T-HIGrow/wiki), there you will find a comprehensive tutorial to help you implement this card.
 
 
 ## Disclaimer

--- a/src/read-sensors.h
+++ b/src/read-sensors.h
@@ -39,7 +39,7 @@ int16_t readSoil()
 
   Serial.print(" Soil max (air): ");
   Serial.println(soil_max);
-  Serial.print(" Sil min (water): ");
+  Serial.print(" Soil min (water): ");
   Serial.println(soil_min);
 
   if (soil == 0) // ERROR


### PR DESCRIPTION
## Summary
- correct `toturial` typo in README
- fix 'Sil min (water)' debug print in `read-sensors.h`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6842e6e68e30832cb627d3df698a7b05