### PR TITLE
Implement MQTT auto-discovery in firmware

### DIFF
--- a/src/save-configuration.h
+++ b/src/save-configuration.h
@@ -14,6 +14,65 @@ String floatToString(float value) {
   }
 }
 
+struct HASensor {
+  const char *key;
+  const char *name;
+  const char *unit;
+  const char *device_class;
+  const char *state_class;
+  const char *icon;
+};
+
+void publishDiscovery(const String &chipId) {
+  StaticJsonDocument<256> device;
+  device["identifiers"][0] = chipId;
+  device["manufacturer"] = "LILYGO, programmed by github.com/cybdis";
+  device["model"] = "TTGO T-Higrow";
+  device["name"] = plant_name;
+  device["sw_version"] = rel;
+
+  const HASensor sensors[] = {
+      {"sensorname", "Name", nullptr, nullptr, nullptr, nullptr},
+      {"Tgrow_HIGrow", "Mac-ID", nullptr, nullptr, nullptr, nullptr},
+      {"updated", "Updated", nullptr, "timestamp", nullptr, "mdi:update"},
+      {"sleep5Count", "Sleep5count", nullptr, nullptr, nullptr, "mdi:counter"},
+      {"bootCount", "Bootcount", nullptr, nullptr, nullptr, "mdi:counter"},
+      {"lux", "Lux", "lx", "illuminance", "measurement", "mdi:weather-sunny"},
+      {"temp", "Temperature", "°C", "temperature", "measurement", "mdi:thermometer"},
+      {"humid", "Humidity", "%", "humidity", "measurement", "mdi:water-percent"},
+      {"soil", "Soil", "%", "moisture", "measurement", "mdi:raw"},
+      {"soilTemp", "SoilTemp", "°C", "temperature", "measurement", "mdi:thermometer"},
+      {"water", "Water", "%", nullptr, "measurement", "mdi:waves-arrow-up"},
+      {"salt", "Fertilizer", "%", nullptr, "measurement", "mdi:bottle-tonic"},
+      {"saltadvice", "Fertilize state", nullptr, nullptr, nullptr, "mdi:alpha-i-circle-outline"},
+      {"bat", "Battery", "%", "battery", "measurement", "mdi:battery"},
+      {"batcharge", "Charging", nullptr, nullptr, nullptr, "mdi:battery"},
+      {"batchargeDate", "batchargeDate", nullptr, nullptr, nullptr, "mdi:calendar"},
+      {"daysOnBattery", "daysOnBattery", "days", nullptr, nullptr, "mdi:calendar"},
+      {"wifissid", "WIFI", nullptr, nullptr, nullptr, "mdi:wifi"},
+      {"pressure", "Pressure", "Hpa", nullptr, "measurement", "mdi:gauge"},
+      {"plantValveNo", "plantValveNo", nullptr, nullptr, nullptr, nullptr},
+      {"rel", "Release", nullptr, nullptr, nullptr, "mdi:counter"}
+  };
+
+  for (const auto &s : sensors) {
+    StaticJsonDocument<512> doc;
+    doc["name"] = s.name;
+    if (s.unit) doc["unit_of_meas"] = s.unit;
+    if (s.device_class) doc["device_class"] = s.device_class;
+    if (s.state_class) doc["state_class"] = s.state_class;
+    if (s.icon) doc["icon"] = s.icon;
+    doc["val_tpl"] = String("{{ value_json.plant.") + s.key + " }}";
+    doc["uniq_id"] = String("TTGO_") + chipId + "_" + s.key;
+    doc["stat_t"] = device_name + "/" + chipId;
+    doc["dev"] = device;
+    String topic = String("homeassistant/sensor/Tgrow_HIGrow_") + chipId + "/" + s.key + "/config";
+    char buffer[512];
+    serializeJson(doc, buffer);
+    mqttClient.publish(topic.c_str(), buffer, true);
+  }
+}
+
 // Allocate a  JsonDocument
 void saveConfiguration(const Config & config) {
 
@@ -105,7 +164,9 @@ void saveConfiguration(const Config & config) {
   }
 
   Serial.println("You're connected to the MQTT broker! Publishing...");
-  
+
+  publishDiscovery(chipId);
+
   bool retained = true;
 
   if (mqttClient.publish(topic, buffer, retained)) {


### PR DESCRIPTION
## Summary
- publish Home Assistant discovery topics directly from firmware
- send discovery after connecting to MQTT broker

## Testing
- ❌ `pio run` *(missing PlatformIO: Could not find a version that satisfies the requirement platformio)*

------
https://chatgpt.com/codex/tasks/task_e_68babfcfa64c832cb3c67b55451a0f91