### PR TITLE
Remove dead Sleep5Count feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file.
 
+## [5.5.2] - 2026-07-24
+
+### Removed
+- **Sleep5Count sensor**: dead feature. The RTC counter was declared but never incremented, and never copied into the `config` struct sent to Home Assistant, so the `Sleep5count` sensor always reported `0`. Removed the RTC variable, the `Config.sleep5no` field, the HA Discovery sensor/topic, and the legacy JSON key
+
+---
+
 ## [5.5.0] - 2026-07-17
 
 ### Added

--- a/src/home-assistant-discovery.h
+++ b/src/home-assistant-discovery.h
@@ -38,7 +38,7 @@ HAMqtt mqtt(wifiClient, device);
 String globalNameId, globalMacId, globalLuxId, globalTempId, globalHumId, globalSoilId,
        globalSoilRawId, globalSoilCalId, globalSaltId, globalSaltAdvId, globalBatId,
        globalBatChargeId, globalBatChargeDateId, globalDaysId, globalPressId, globalWifiId,
-       globalValveId, globalRelId, globalUpdId, globalSlp5Id, globalBootId;
+       globalValveId, globalRelId, globalUpdId, globalBootId;
 
 HASensor* sensorLux;
 HASensor* sensorTemp;
@@ -56,7 +56,6 @@ HASensor* sensorPressure;
 HASensor* sensorName;
 HASensor* sensorMacId;
 HASensor* sensorUpdated;
-HASensor* sensorSleep5Count;
 HASensor* sensorBootCount;
 HASensor* sensorWifiSSID;
 HASensor* sensorPlantValveNo;
@@ -113,13 +112,6 @@ void sendDiscoveryTopic() {
   sensorUpdated->setIcon("mdi:update");
   sensorUpdated->setForceUpdate(true);
   
-  globalSlp5Id = "TTGO_" + chipId + "_sleep5Count";
-  sensorSleep5Count = new HASensor(globalSlp5Id.c_str());
-  sensorSleep5Count->setName("Sleep5count");
-  sensorSleep5Count->setUnitOfMeasurement("count");
-  sensorSleep5Count->setIcon("mdi:counter");
-  sensorSleep5Count->setStateClass("total_increasing");
-
   globalBootId = "TTGO_" + chipId + "_bootCount";
   sensorBootCount = new HASensor(globalBootId.c_str());
   sensorBootCount->setName("Bootcount");
@@ -273,7 +265,6 @@ void updateHASensors(const Config& config) {
   
   sensorUpdated->setValue(config.updated.c_str());
   
-  sensorSleep5Count->setValue(String(config.sleep5no).c_str());
   sensorBootCount->setValue(String(config.bootno).c_str());
   sensorLux->setValue(formatSensorValue(config.lux).c_str());  // 1 decimal place
   
@@ -307,7 +298,6 @@ void updateHASensors(const Config& config) {
   mqttLog(sensorMacId,         chipId);
   mqttLog(sensorUpdated,       config.updated);
   mqttLog(sensorBootCount,     String(config.bootno));
-  mqttLog(sensorSleep5Count,   String(config.sleep5no));
   mqttLog(sensorLux,           formatSensorValue(config.lux));
   mqttLog(sensorTemp,          formatSensorValue(config.temp));
   mqttLog(sensorHumid,         formatSensorValue(config.humid, true));

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -65,7 +65,8 @@
 //           rel = "5.4.0"; // OTA update: pull firmware from Home Assistant /local on every wake, deploy via "pio run -t ota_deploy"
 //           rel = "5.4.1"; // Soil/Salt measured BEFORE WiFi (weak battery + WiFi load sags sensor rail, false 100% soil); soil now uses the same 120-sample trimmed mean as salt
 //           rel = "5.5.0"; // Wake-ups aligned to the clock grid: sleep duration is computed to the next full hour (3600), half hour (1800), etc. based on NTP time
-const String rel = "5.5.1"; // Fixed corrupted/truncated HA discovery MQTT payloads: removed a second, never-connected PubSubClient that was injecting publishes onto ArduinoHA's live MQTT session on the same socket; legacy JSON topic now published via the single shared ArduinoHA client
+//           rel = "5.5.1"; // Fixed corrupted/truncated HA discovery MQTT payloads: removed a second, never-connected PubSubClient that was injecting publishes onto ArduinoHA's live MQTT session on the same socket; legacy JSON topic now published via the single shared ArduinoHA client
+const String rel = "5.5.2"; // Removed Sleep5Count: the RTC counter was never incremented and never copied into config, so the HA sensor always reported 0
 
 // mqtt constants
 WiFiClient wifiClient;
@@ -79,7 +80,6 @@ float daysOnBattery;
 
 // Reboot counters
 RTC_DATA_ATTR int bootCount = 0;
-RTC_DATA_ATTR int sleep5no = 0;
 
 // Sensor bools
 bool bme_found = false;
@@ -91,7 +91,6 @@ struct Config
   // String time;
   String updated;
   int bootno;
-  int sleep5no;
   float lux;
   float temp;
   float humid;

--- a/src/save-configuration.h
+++ b/src/save-configuration.h
@@ -54,7 +54,6 @@ void saveConfiguration(const Config & config) {
   plant["updated"] = config.updated;
   // plant["date"] = config.date;
   // plant["time"] = config.time;
-  plant["sleep5Count"] = config.sleep5no;
   plant["bootCount"] = config.bootno;
   plant["lux"] = floatToString(config.lux);
   plant["temp"] = floatToString(config.temp);


### PR DESCRIPTION
The RTC counter was declared but never incremented and never copied into the config struct, so the Sleep5count HA sensor always reported 0. Removed the RTC variable, the Config.sleep5no field, the HA Discovery sensor/topic, and the legacy JSON key.